### PR TITLE
Enforce CLA checks in bracket repositories

### DIFF
--- a/.github/workflows/python/validate_cla_signature.py
+++ b/.github/workflows/python/validate_cla_signature.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import json
+import subprocess
+import re
+
+def extract_personal_contributer_details():
+	f = open(os.getcwd() + '/personal_contributor_licence_agreement.md')
+	personal_cla_contents = f.read()
+
+	personal_contributers_regex = re.compile('\| *\[([^\s]+)\]\([^\s]+\) *\|')
+	personal_contributers = personal_contributers_regex.findall(personal_cla_contents)
+
+	return personal_contributers
+
+
+def extract_employer_contributer_details():
+	f = open(os.getcwd() + '/employer_contributor_license_agreement.md')
+	employer_cla_contents = f.read()
+
+	employer_contributers_regex = re.compile('\| *\[([^\s]+)\]\([^\s]+\) *\|')
+	employer_contributers = employer_contributers_regex.findall(employer_cla_contents)
+
+	return employer_contributers
+
+
+print("current working directory is: ", os.getcwd())
+
+github_info_file = open('./.tmp/github.json', 'r') 
+github_details = json.load(github_info_file)
+
+commit_info_file = open('./.tmp/commitDetails.json', 'r') 
+commit_details = json.load(commit_info_file)
+
+if github_details["event_name"] != "pull_request":
+    print("Error! This operation is valid on github pull requests. Exiting")
+    sys.exit(1)
+
+print("Pull request submitted by github login: ", github_details['event']['pull_request']['user']['login'])
+print("Number of commits in the pull request: ", len(commit_details))
+
+# Check if current dir is git dir
+is_git_dir = subprocess.check_output(
+        ['/usr/bin/git', 'rev-parse', '--is-inside-work-tree']).decode('utf-8')
+print("Is git dir: ", is_git_dir)
+
+# git status
+git_status = subprocess.check_output(
+        ['/usr/bin/git', 'status']).decode('utf-8')
+print("Git status: ", git_status)
+
+# last n commits
+last_n_commit_list = subprocess.check_output(
+        ['/usr/bin/git', 'rev-list', '--max-count=10', 'HEAD']).decode('utf-8')
+print("last 10 commit ids are: ", last_n_commit_list)
+
+# github logins of all committers
+commit_logins = []
+
+for commit in commit_details:
+    commiter_github_login = commit['committer']['login']
+    if commiter_github_login not in commit_logins:
+        commit_logins.append(commiter_github_login)
+	
+print("All github users who made changes to the pull request: ", commit_logins)
+
+# github login of all contributers who has signed personal CLA
+personal_contributers = extract_personal_contributer_details()
+# github login of all contributers who has signed employer CLA
+employer_contributers = extract_employer_contributer_details()
+
+for user in commit_logins:
+    if user != 'web-flow' and user not in personal_contributers and user not in employer_contributers:
+        print("Error!" + user + "has not signed the contributer licence agreement.")
+        sys.exit(1)
+
+

--- a/.github/workflows/validate_cla_signature.yml
+++ b/.github/workflows/validate_cla_signature.yml
@@ -1,4 +1,4 @@
-name: Print pull request details.
+name: Enforce CLA Signature
 # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
 
 on: 

--- a/.github/workflows/validate_cla_signature.yml
+++ b/.github/workflows/validate_cla_signature.yml
@@ -1,0 +1,49 @@
+name: Print pull request details.
+# https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
+
+on: 
+  pull_request:
+    branches:
+      - enforce-cla-checks
+
+jobs:
+  validate-cla-signature:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setting temp directory
+        run: | 
+          mkdir ./.tmp
+      - name: Getting commit details
+        uses: wei/wget@v1
+        with:
+          args: -O ./.tmp/commitDetails.json ${{ toJSON(github.event.pull_request._links.commits.href) }}
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: | 
+          echo "$GITHUB_CONTEXT" > ./.tmp/github.json
+          cat ./.tmp/github.json
+          echo "commit details: "
+          cat ./.tmp/commitDetails.json
+      - name: CLA signature check
+        run: |
+          which git
+          if ! python ./.github/workflows/python/validate_cla_signature.py; then
+              echo "Please sign the Contributer Licence Agreement before contributing to this repository."
+              echo "You can sign the CLA here: http://brackets.io/contributor-license-agreement/"
+              exit 1
+          else
+              echo "all good"
+          fi
+      

--- a/.github/workflows/validate_cla_signature.yml
+++ b/.github/workflows/validate_cla_signature.yml
@@ -4,7 +4,7 @@ name: Print pull request details.
 on: 
   pull_request:
     branches:
-      - enforce-cla-checks
+      - main
 
 jobs:
   validate-cla-signature:

--- a/Test.txt
+++ b/Test.txt
@@ -1,0 +1,8 @@
+This is a test file
+Test 2
+Test 3
+Test 4
+Test 5
+Test 6
+Test 7
+Test 8

--- a/Test.txt
+++ b/Test.txt
@@ -1,8 +1,0 @@
-This is a test file
-Test 2
-Test 3
-Test 4
-Test 5
-Test 6
-Test 7
-Test 8

--- a/personal_contributor_licence_agreement.md
+++ b/personal_contributor_licence_agreement.md
@@ -79,3 +79,4 @@ I agree with all the terms and conditions above by providing my details in **tab
 ## **Table-A**: Signed by
 | Name (“You”) | Github ID | Date |
 | --- | --- | --- |
+| `Dhanesh P S`| [psdhanesh7](https://github.com/psdhanesh7) |13-November-2021|


### PR DESCRIPTION
Contribution from friends @phoenix project 

Created a GitHub action on a pull request and merge in brackets and brackets-shell repo if the user has signed CLA.
Action fails and message the user to sign CLA if not signed.

Completed issue #5.